### PR TITLE
Fix the non-reordering of tasks and subtasks after deleting one

### DIFF
--- a/app/javascript/controllers/cards_controller.js
+++ b/app/javascript/controllers/cards_controller.js
@@ -45,6 +45,10 @@ export default class extends Controller {
     setButtonTogglers(this.element.id)
   }
 
+  cardOrderTargetConnected(target) {
+    log(target.innerHTML)
+  }
+
   onReorder(e) {
     this.#updateBackEnd()
   }
@@ -56,7 +60,11 @@ export default class extends Controller {
     this.unChecked.classList.toggle('d-none')
     this.checked.classList.toggle('d-none')
     this.element.classList.toggle('card-checked')
-    // log(this.element.id)
+
+    // Check to see if the subtasks are all checked
+    // Should a checked task's subtasks be checked?
+    log('To-do: task/Subtasks consistency check!?')
+
     this.#updateBackEnd()
 
   }

--- a/app/javascript/controllers/dragula_controller.js
+++ b/app/javascript/controllers/dragula_controller.js
@@ -1,7 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
 
-let counter = 0;
-
 const log = something => console.log(typeof something, something)
 
 // Connects to data-controller="dragula"
@@ -10,9 +8,9 @@ export default class extends Controller {
   static targets = [ "dracule" ]
 
   initialize() {
+    this.count = this.element.children.length
 
-    counter += 1
-
+    // Should not be needed as the cards/tasks are already ordered on creation
     // let reap = this.element.querySelectorAll(':scope > .task');
     // if (reap.length) {
     //   this.#setCardOrdinals(reap);
@@ -21,43 +19,71 @@ export default class extends Controller {
     //   this.#setCardOrdinals(reap);
     // }
 
+    // Making the subtasks dragable is not working as expected??? Fix this!
     const drake = dragula([this.element], {
-      // moves: (el, container, handle) => handle.classList.contains('handle'),
-      // revertOnSpill: true,
-      // accepts: (el, target, source, sibling) => {
-      //   // log(sibling)
-      //   return true;
-      // }
+      moves: (el, container, handle) => handle.classList.contains('handle')
     });
 
+    // This is the event that is fired when a task is dropped.
+    // It will reset the task ordinals to reflect the new order.
     drake.on('drop', (el, target) => {
-      const alucard = el.parentNode.children
-      this.#setCardOrdinals(alucard)
+      this.updateOrdinals(target.children)
     });
 
+    // This is where we watch for when a task/subtask is deleted.
+    // Hotwire does not seem to support a 'delete' or turbo-frame remove event
+    // so we have to use the 'childList' event of the MutationObserver class to
+    // detect when a task/subtask is deleted. Then we reset the task ordinals
+    // to reflect the new order.
+    //
+    // 1. Select the node that will be observed for mutations
+    const targetNode = this.element
+    // 2. Set the otions for the observer (which mutations to observe) we want
+    //    to observe just the direct children of the target node - 'dragular'
+    const config = { childList: true }
+    // 3. Setup the callback function to execute when mutations are observed.
+    const callback = (mutationList, observer) => {
+      for (const mutation of mutationList) {
+        if (mutation.type === "childList") {
+          // console.log(`${mutation.target.id}`)
+          // console.log(this.count, this.element.children.length)
+          if (this.count !== this.element.children.length) {
+            // Then we have deleted a child node
+            // Or we've switched em out for a form but
+            // updateOrdinals will take care of it
+            this.updateOrdinals(this.element.children)
+            this.count = this.element.children.length
+          }
+        }
+      }
+    }
+    // 4. Create an observer instance and link it to the callback function. And,
+    this.observer = new MutationObserver(callback)
+    // 5. Start observing the target node for configured mutations
+    this.observer.observe(targetNode, config)
+
   }
 
-  connect() { }
-
-  onDeleteTask(e) {
-    // e.preventDefault()
-    this.#setCardOrdinals(this.draculeTarget.children)
-  }
+  connect() {}
 
   updateOrdinals(e) {
-    const domEls = e.target.hasChildNodes() ? e.target.children : false
-    if (domEls && domEls.length && domEls[0].tagName != "FORM") {
-      this.#setCardOrdinals(domEls)
+    const turboCards = this.element.hasChildNodes() ? this.element.children : false
+    if (turboCards && turboCards.length && turboCards[0].tagName != "FORM") {
+      const event = new Event("change")
+      Array.from(turboCards).forEach((card, i) => {
+        const j = i + 1;
+        const orderWrap = card.querySelectorAll('.card-header span.order-wrapper')[0]
+        orderWrap.innerText = j
+        orderWrap.dispatchEvent(event)
+      })
     }
   }
 
-  #setCardOrdinals(cards) {
-    const event = new Event("change")
-    // Array.from(cards).forEach((card, i) => {
-    //   const j = i + 1;
-    //   const orderWrap = card.querySelectorAll('.card-header span.order-wrapper')[0]
-    //   orderWrap.innerText = j
-    //   orderWrap.dispatchEvent(event)
-    // })
+  disconnect() {
+    this.observer.disconnect();
+  }
+
+  #printCount() {
+    log(`${this.element.id} has ${this.count} children`)
   }
 }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -43,7 +43,11 @@ class Task < ApplicationRecord
     self.start_date = Time.now
   end
 
+  # Will return the highest order number for the task
+  # If no tasks exist for the user and routine, will return 1
   def set_initial_order
+    # Think we will need to revisit when we start working on the journal
+    #   logs i.e. daily log, etc. with different days...
     count = Task.where(user_id: self.user_id, routine: self.routine).maximum(:order)
     self.order = count.nil? ? 1 : count + 1
   end

--- a/app/views/subtasks/_form.html.erb
+++ b/app/views/subtasks/_form.html.erb
@@ -3,7 +3,7 @@
     id: "#{ dom_id subtask }",
     class: "subtask subtask-form m-3 p-2",
     data: {
-      controller: "cards form"
+      controller: "cards"
     }
   }) do |f| %>
 
@@ -14,19 +14,66 @@
 
       <div class="form-inputs">
 
-        <%= f.input :order, label: false, input_html: { id: "#{ dom_id subtask }_order", class: "d-none form-control mb-3" } %>
+        <%= f.input :order,
+          label: false,
+          input_html: {
+            id: "#{ dom_id subtask }_order",
+            class: "d-none form-control"
+          }, wrapper_html: {
+            class: "d-none m-0",
+          } %>
 
-        <%= f.input :title, label: false, placeholder: "Subtask title here...", input_html: { class: "form-control mb-3" } %>
+        <%= f.input :title,
+          label: false,
+          placeholder: "Subtask title here...",
+          input_html: {
+            class: "form-control mb-3"
+          } %>
 
-        <%= f.input :description, as: :text, label: false, placeholder: "Add a description...", input_html: { class: "form-control mb-3", 'rows' => 3, 'cols' => 10 } %>
+        <%= f.input :description, as: :text,
+          label: false,
+          placeholder: "Add a description...",
+          input_html: {
+            class: "form-control mb-3",
+            rows: 3,
+            cols: 10
+          } %>
 
-        <%#= f.input :comment, as: :text, input_html: { hidden: true, class: "form-control mb-3", 'rows' => 3, 'cols' => 10 } %>
+        <%= f.input :comment, as: :text,
+          label: false,
+          input_html: {
+            class: "d-none form-control",
+            rows: 3,
+            cols: 10
+          },
+          wrapper_html: {
+            class: "d-none m-0"
+          } %>
 
-        <%#= f.input :start_date, html5: true, input_html: { class: "form-control mb-3" } %>
+        <%= f.input :start_date, html5: true,
+          label: false,
+          input_html: {
+            class: "form-control mb-3"
+          } %>
 
-        <%#= f.input :due_date, html5: true, input_html: { class: "form-control mb-3" } %>
+        <%= f.input :due_date, html5: true,
+          label: false,
+          input_html: {
+            class: "d-none form-control"
+          },
+          wrapper_html: {
+            class: "d-none m-0"
+          } %>
 
-        <%= f.input :completed, as: :boolean, input_html: { id: "#{dom_id subtask}_completed", class: "d-none form-control mb-3" } %>
+        <%= f.input :completed, as: :boolean,
+          label: false,
+          input_html: {
+            id: "#{dom_id subtask}_completed",
+            class: "d-none form-control"
+          },
+          wrapper_html: {
+            class: "d-none m-0"
+          } %>
 
       </div>
 

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -13,27 +13,89 @@
 
   <div class="form-inputs">
 
-    <%= f.input :order, label: false, input_html: { id: "#{ dom_id task }_order", class: "d-n one order" } %>
+    <%= f.input :order,
+      label: false,
+      input_html: {
+        id: "#{dom_id task}_order",
+        class: "d-none order"
+      } %>
 
-    <%= f.input :routine, as: :hidden, label: false, collection: Task::transform_routines_for_html_select, input_html: { class: "form-control mb-3" } %>
+    <%= f.input :routine,
+      label: false,
+      collection: Task::transform_routines_for_html_select,
+      input_html: {
+        class: "d-none form-control"
+      } %>
 
     <%= f.input :recurs_on, as: :check_boxes, as: :hidden, label: false, input_html: { class: "form-control mb-3" } %>
 
-    <%= f.input :task_type, label: false, collection: Task::transform_task_types_for_html_select, input_html: { class: "form-control mb-3" } %>
+    <%= f.input :task_type,
+      label: false,
+      collection: Task::transform_task_types_for_html_select,
+      input_html: {
+        class: "form-control mb-3"
+      } %>
 
-    <%= f.input :title, label: false, placeholder: "Task title...", input_html: { class: "form-control mb-3" } %>
+    <%= f.input :title,
+      label: false,
+      placeholder: "Task title...",
+      input_html: {
+        class: "form-control mb-3"
+      } %>
 
-    <%= f.input :description, as: :text, label: false, placeholder: "Add a description here...", input_html: { class: "form-control mb-3", 'rows' => 3, 'cols' => 10 } %>
+    <%= f.input :description, as: :text,
+      label: false,
+      placeholder: "Add a description here...",
+      input_html: {
+        class: "form-control mb-3",
+        rows: 10,
+        cols: 10
+      } %>
 
-    <%= f.input :comment, as: :text, as: :hidden, label: false, input_html: { hidden: true, class: "form-control mb-3", 'rows' => 3, 'cols' => 10 } %>
+    <%= f.input :comment, as: :text,
+      label: false,
+      input_html: {
+        class: "d-none form-control",
+        rows: 10,
+        cols: 10
+      },
+      wrapper_html: {
+        class: "d-none m-0"
+      } %>
 
-    <%= f.input :start_date, html5: true, label: false, input_html: { class: "form-control mb-3" } %>
+    <%= f.input :start_date, html5: true,
+      label: false,
+      input_html: {
+        class: "form-control mb-3"
+      } %>
 
-    <%= f.input :due_date, html5: true, as: :hidden, label: false, input_html: { class: "form-control mb-3" } %>
+    <%= f.input :due_date, html5: true,
+      label: false,
+      input_html: {
+        class: "d-none form-control"
+      },
+      wrapper_html: {
+        class: "d-none m-0"
+      } %>
 
-    <%= f.input :completed, as: :boolean, label: false, input_html: { id: "#{dom_id task}_completed", class: "d-none form-control mb-3" } %>
+    <%= f.input :completed, as: :boolean,
+      label: false,
+      input_html: {
+        id: "#{dom_id task}_completed",
+        class: "d-none form-control"
+      },
+      wrapper_html: {
+        class: "d-none m-0"
+      } %>
 
-    <%= f.input :active, as: :boolean, as: :hidden, label: false, input_html: { hidden: true, class: "form-control mb-3" } %>
+    <%= f.input :active, as: :boolean,
+      label: false,
+      input_html: {
+        class: "d-none form-control"
+      },
+      wrapper_html: {
+        class: "d-none m-0"
+      } %>
 
   </div>
 
@@ -55,10 +117,10 @@
       <%= link_to_add_nested(
         f,
         :subtasks,
-        "#subtasks_for_#{ dom_id task }",
+        "#subtasks_for_#{dom_id task}",
         partial_form_variable: :f,
         tag_attributes: {
-          class: "Add-nested-assoc",
+          class: "add-nested-assoc",
           title: "Add a subtask"
         },
         link_classes: 'btn btn-sm btn-primary m-1'
@@ -73,7 +135,7 @@
 
   <div class="form-actions links d-flex justify-content-end align-items-center">
 
-    <%= render 'links', task: task %>
+    <%#= render 'links', task: task %>
 
     <%= button_tag type: 'submit', class: "btn btn-primary" do %>
 

--- a/app/views/tasks/_subtask_card.html.erb
+++ b/app/views/tasks/_subtask_card.html.erb
@@ -7,7 +7,10 @@
   <div class="card-header d-flex justify-content-between align-items-center">
 
     <h3 class="card-title">
-      <span class="checkbox-wrapper"></span>
+
+      <%#= <i class="fa-solid fa-grip handle"></i> %>
+
+      <span class="checkbox-wrapper">
 
         <label data-action="click->cards#onChecked"
           data-cards-target="cardFauxCheck"
@@ -72,8 +75,7 @@
         <%= link_to(task_subtask_path(subtask.task_id, subtask.id),
           data: {
             turbo_method: :delete,
-            turbo_confirm: "Are you sure?",
-            action: "click->dragula#updateOrdinals"
+            turbo_confirm: "Are you sure?"
           },
           class: "btn btn-danger m-1",
           title: "Delete this task?"

--- a/app/views/tasks/_subtask_fields.html.erb
+++ b/app/views/tasks/_subtask_fields.html.erb
@@ -1,19 +1,65 @@
 <%# :order, :title, :description, :comment, :start_date, :due_date, :completed %>
 <div class="subtask-fields card m-1 p-2">
 
-  <%= f.input :order, label: false, input_html: { class: "d-none mb-3" } %>
+  <%= f.input :order,
+    label: false,
+    input_html: {
+      class: "d-none"
+    },
+    wrapper_html: {
+      class: "d-none m-0"
+    } %>
 
-  <%= f.input :title, label: false, placeholder: "Subtask title here...", input_html: { class: "mb-3" } %>
+  <%= f.input :title,
+    label: false,
+    placeholder: "Subtask title goes here...",
+    input_html: {
+      class: "form-control"
+    } %>
 
-  <%= f.input :description, as: :text, label: false, placeholder: "More detail here...", input_html: { class: "mb-3", 'rows' => 5, 'cols' => 10 } %>
+  <%= f.input :description, as: :text,
+    label: false,
+    placeholder: "More detail here...",
+    input_html: {
+      class: "form-control mb-3",
+      rows: 5,
+      cols: 10
+    } %>
 
-  <%#= f.input :comment, as: :text, input_html: { class: "mb-3", 'rows' => 5, 'cols' => 10 } %>
+  <%= f.input :comment, as: :text,
+    label: false,
+    placeholder: "Comment here...",
+    input_html: {
+      class: "d-none",
+      rows: 5, cols: 10
+    },
+    wrapper_html: {
+      class: "d-none m-0"
+    } %>
 
-  <%= f.input :start_date, html5: true, label: false, input_html: { class: "mb-3" } %>
+  <%= f.input :start_date, html5: true,
+    label: false,
+    input_html: {
+      class: "form-control mb-3"
+    } %>
 
-  <%= f.input :due_date, as: :hidden, html5: true, input_html: { class: "mb-3" } %>
+  <%= f.input :due_date, html5: true,
+    label: false,
+    input_html: {
+      class: "d-none"
+    },
+    wrapper_html: {
+      class: "d-none m-0"
+    } %>
 
-  <%= f.input :completed, as: :boolean, label: false, input_html: { class: "d-none" } %>
+  <%= f.input :completed, as: :boolean,
+    label: false,
+    input_html: {
+      class: "d-none"
+    },
+    wrapper_html: {
+      class: "d-none m-0"
+    } %>
 
   <div class="subtask-controls d-flex justify-content-end align-items-center">
 

--- a/app/views/tasks/_task_card.html.erb
+++ b/app/views/tasks/_task_card.html.erb
@@ -8,7 +8,7 @@
 
     <h3 class="card-title">
 
-      <i class="fa-solid fa-grip"></i>
+      <i class="fa-solid fa-grip handle"></i>
 
       <span class="checkbox-wrapper">
 
@@ -110,8 +110,7 @@
         <%= link_to(task_path(task),
           data: {
             turbo_method: :delete,
-            turbo_confirm: "Are you sure?",
-            action: "click->dragula#onDeleteTask"
+            turbo_confirm: "Are you sure?"
           },
           class: "btn btn-danger m-1",
           title: "Delete this task?"
@@ -141,11 +140,7 @@
     data-task-buttons-target="subtasks"
     data-subtasks-count="<%= task.subtasks.length %>">
 
-    <%= turbo_frame_tag "new_subtask_for_#{ dom_id task }",
-      data: {
-        controller: "dragula",
-        action: "turbo:frame-render->dragula#updateOrdinals"
-      } do %>
+    <%= turbo_frame_tag "new_subtask_for_#{ dom_id task }", data: { controller: "dragula" } do %>
 
       <% if task.subtasks.length.positive? %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -29,7 +29,7 @@
 
       <div class="cards tasks-container collapse-container">
 
-        <%= turbo_frame_tag @turbo_frame_id, data: { controller: "dragula", dragula_target: "dracule" } do %>
+        <%= turbo_frame_tag @turbo_frame_id, data: { controller: "dragula" } do %>
 
           <% @tasks.each do |task| %>
 


### PR DESCRIPTION
Fixed this issue by adding a MutationObserver to the dragula controller. This has allowed me to watch for when a task/subtask is deleted and am then able to reset the task ordinals to reflect the new order. This has also allowed me to clean up the html as well.